### PR TITLE
Initial implementation for collect command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.0-alpine
+FROM ucalgary/python-librdkafka:3.6.0-0.9.2
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app
 RUN apk add --no-cache --virtual .build-deps \
       gcc \
+      git \
       musl-dev && \
     pip install -r requirements.txt && \
 		apk del .build-deps

--- a/pssync/cli/docopt_command.py
+++ b/pssync/cli/docopt_command.py
@@ -8,48 +8,48 @@ from docopt import DocoptExit
 
 
 def docopt_full_help(docstring, *args, **kwargs):
-	try:
-		return docopt(docstring, *args, **kwargs)
-	except DocoptExit:
-		raise SystemExit(docstring)
+    try:
+        return docopt(docstring, *args, **kwargs)
+    except DocoptExit:
+        raise SystemExit(docstring)
 
 
 class DocoptDispatcher(object):
 
-	def __init__(self, command_class, options):
-		self.command_class = command_class
-		self.options = options
+    def __init__(self, command_class, options):
+        self.command_class = command_class
+        self.options = options
 
-	def parse(self, argv):
-		command_help = getdoc(self.command_class)
-		options = docopt_full_help(command_help, argv, **self.options)
-		command = options['COMMAND']
+    def parse(self, argv):
+        command_help = getdoc(self.command_class)
+        options = docopt_full_help(command_help, argv, **self.options)
+        command = options['COMMAND']
 
-		if command is None:
-			raise SystemExit(command_help)
+        if command is None:
+            raise SystemExit(command_help)
 
-		handler = get_handler(self.command_class, command)
-		docstring = getdoc(handler)
+        handler = get_handler(self.command_class, command)
+        docstring = getdoc(handler)
 
-		if docstring is None:
-			raise NoSuchCommand(command, self)
+        if docstring is None:
+            raise NoSuchCommand(command, self)
 
-		command_options = docopt_full_help(docstring, options['ARGS'], options_first=True)
-		return options, handler, command_options
+        command_options = docopt_full_help(docstring, options['ARGS'], options_first=True)
+        return options, handler, command_options
 
 
 def get_handler(command_class, command):
-	command = command.replace('-', '_')
+    command = command.replace('-', '_')
 
-	if not hasattr(command_class, command):
-		raise NoSuchCommand(command, command_class)
+    if not hasattr(command_class, command):
+        raise NoSuchCommand(command, command_class)
 
-	return getattr(command_class, command)
+    return getattr(command_class, command)
 
 
 class NoSuchCommand(Exception):
-	def __init__(self, command, supercommand):
-		super(NoSuchCommand, self).__init__("No such command: %s" % command)
+    def __init__(self, command, supercommand):
+        super(NoSuchCommand, self).__init__("No such command: %s" % command)
 
-		self.command = command
-		self.supercommand = supercommand
+        self.command = command
+        self.supercommand = supercommand

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -56,7 +56,7 @@ class PSSyncCommand(object):
 	  pssync -h|--help
 
 	Options:
-	  -b, --broker BROKER_HOSTS     Comma-separated list of Kafka broker hosts (default: kafka:9092)
+	  -b, --broker BROKER_HOSTS     Comma-separated list of Kafka broker hosts [default: kafka:9092]
 	  -r, --registry REGISTRY_HOST  URL of the service where Avro schemas are registered
 	  -p, --topic-prefix PREFIX     String to prepend to all topic names
 

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -72,7 +72,7 @@ class PSSyncCommand(object):
 		Usage: collect [options]
 
 		Options:
-		  --port PORT                Port to listen to messages on (default: 8000)
+		  --port PORT                Port to listen to messages on [default: 8000]
 		  --sender-name NAMES        Accepted values for the From header
 		  --recipient-name NAMES     Accepted values for the To header
 		  --message-name NAMES       Accepted values for the MessageName header

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -89,7 +89,7 @@ class PSSyncCommand(object):
         collector.collect(
           producer,
           topic=command_options['--topic'],
-          port=command_options['--port'],
+          port=int(command_options['--port']),
           senders=command_options['--senders'],
           recipients=command_options['--recipients'],
           message_names=command_options['--messages'])

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -52,13 +52,15 @@ class PSSyncCommand(object):
     """Process PeopleSoft sync messages into Kafka topics.
 
     Usage:
-      pssync [options] [COMMAND] [ARGS...]
+      pssync [--kafka=<arg>]... [--schema-registry=<arg>]
+             [--zookeeper=<arg>] [--topic-prefix=<arg>]
+             [COMMAND] [ARGS...]
       pssync -h|--help
 
     Options:
-      -z, --zookeeper HOST          Zookeeper service discoveryhost [default: zookeeper:2181]
-      -k, --kafka HOSTS             Kafka broker hosts, in lieu of zookeeper [default: kafka:9092]
+      -k, --kafka HOSTS             Kafka brokers [default: kafka:9092]
       -r, --schema-registry URL     Avro schema registry host [default: schema-registry:80]
+      -z, --zookeeper HOST          Zookeeper host [default: zookeeper:2181]
       -p, --topic-prefix PREFIX     String to prepend to all topic names
 
     Commands:

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -76,9 +76,11 @@ class PSSyncCommand(object):
 		  --sender-name NAMES        Accepted values for the From header
 		  --recipient-name NAMES     Accepted values for the To header
 		  --message-name NAMES       Accepted values for the MessageName header
-		  --mode MODE                Produce to a single Kafka topic or multiple topics
-		                             based on message name
+		  --producer-topic TOPIC     Produce to a specific Kafka topic, otherwise
+		                             messages are produced to topics by message name
 		"""
+		
+
 		site = server.Site(PSSyncCollector())
 		endpoint = endpoints.TCP4ServerEndpoint(reactor, 8080)
 		endpoint.listen(site)

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -58,7 +58,6 @@ class PSSyncCommand(object):
     Options:
       -k, --kafka HOSTS             Kafka brokers [default: kafka:9092]
       -r, --schema-registry URL     Avro schema registry host [default: http://schema-registry:80]
-      -z, --zookeeper HOST          Zookeeper host [default: zookeeper:2181]
       -p, --topic-prefix PREFIX     String to prepend to all topic names
 
     Commands:

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -107,3 +107,7 @@ class PSSyncCommand(object):
                                      to a topic based on the consumed message name
         """
         pass
+
+
+def kafka_bootstraps_from_options(options):
+  return ','.join(options['--kafka'])

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -83,8 +83,8 @@ class PSSyncCommand(object):
           --topic TOPIC         Produce to a specific Kafka topic, otherwise
                                 messages are sent to topics by message name
         """
-        bootstraps = kafka_bootstraps_from_options(options)
-        producer = Producer({'bootstrap.servers': bootstraps})
+        config = kafka_config_from_options(options)
+        producer = Producer(config)
 
         collector.collect(
           producer,
@@ -115,5 +115,7 @@ class PSSyncCommand(object):
         pass
 
 
-def kafka_bootstraps_from_options(options):
-  return ','.join(options['--kafka'])
+def kafka_config_from_options(options):
+  return {
+    'bootstrap.servers': ','.join(options['--kafka'])
+  }

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -56,9 +56,9 @@ class PSSyncCommand(object):
 	  pssync -h|--help
 
 	Options:
-	  -b, --broker BROKER_HOSTS     Comma-separated list of Kafka broker hosts [default: kafka:9092]
-	  -r, --registry REGISTRY_HOST  URL of the service where Avro schemas are registered
-	  -z, --zookeeper HOST          Zookeeper host [default: zookeeper:2181]
+	  -z, --zookeeper HOST          Zookeeper service discoveryhost [default: zookeeper:2181]
+	  -k, --kafka HOSTS             Kafka broker hosts, in lieu of zookeeper [default: kafka:9092]
+	  -r, --schema-registry URL     Avro schema registry host [default: schema-registry:80]
 	  -p, --topic-prefix PREFIX     String to prepend to all topic names
 
 	Commands:
@@ -78,7 +78,7 @@ class PSSyncCommand(object):
 		  --recipient-name NAMES     Accepted values for the To header
 		  --message-name NAMES       Accepted values for the MessageName header
 		  --producer-topic TOPIC     Produce to a specific Kafka topic, otherwise
-		                             messages are produced to topics by message name
+		                             messages are sent to topics by message name
 		"""
 		
 

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -57,7 +57,7 @@ class PSSyncCommand(object):
 
     Options:
       -k, --kafka HOSTS             Kafka brokers [default: kafka:9092]
-      -r, --schema-registry URL     Avro schema registry host [default: schema-registry:80]
+      -r, --schema-registry URL     Avro schema registry host [default: http://schema-registry:80]
       -z, --zookeeper HOST          Zookeeper host [default: zookeeper:2181]
       -p, --topic-prefix PREFIX     String to prepend to all topic names
 

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -73,12 +73,12 @@ class PSSyncCommand(object):
         Usage: collect [options]
 
         Options:
-          --port PORT                Port to listen to messages on [default: 8000]
-          --sender-name NAMES        Accepted values for the From header
-          --recipient-name NAMES     Accepted values for the To header
-          --message-name NAMES       Accepted values for the MessageName header
-          --producer-topic TOPIC     Produce to a specific Kafka topic, otherwise
-                                     messages are sent to topics by message name
+          --port PORT           Port to listen to messages on [default: 8000]
+          --senders NAMES       Accepted values for the From header
+          --recipients NAMES    Accepted values for the To header
+          --messages NAMES      Accepted values for the MessageName header
+          --topic TOPIC         Produce to a specific Kafka topic, otherwise
+                                messages are sent to topics by message name
         """
         
 

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -17,91 +17,91 @@ log = logging.getLogger(__name__)
 
 
 def main():
-	command = dispatch()
+    command = dispatch()
 
-	try:
-		command()
-	except (KeyboardInterrupt, signals.ShutdownException):
-		log.error('Aborting.')
-		sys.exit(1)
-	except:
-		sys.exit(1)
+    try:
+        command()
+    except (KeyboardInterrupt, signals.ShutdownException):
+        log.error('Aborting.')
+        sys.exit(1)
+    except:
+        sys.exit(1)
 
 
 def dispatch():
-	dispatcher = DocoptDispatcher(
-		PSSyncCommand,
-		{'options_first': True})
+    dispatcher = DocoptDispatcher(
+        PSSyncCommand,
+        {'options_first': True})
 
-	try:
-		options, handler, command_options = dispatcher.parse(sys.argv[1:])
-	except NoSuchCommand as e:
-		commands = '\n'.join(parse_doc_section('commands:', getdoc(e.supercommand)))
-		log.error('No such command: %s\n\n%s', e.command, commands)
-		sys.exit(1)
+    try:
+        options, handler, command_options = dispatcher.parse(sys.argv[1:])
+    except NoSuchCommand as e:
+        commands = '\n'.join(parse_doc_section('commands:', getdoc(e.supercommand)))
+        log.error('No such command: %s\n\n%s', e.command, commands)
+        sys.exit(1)
 
-	return functools.partial(perform_command, options, handler, command_options)
+    return functools.partial(perform_command, options, handler, command_options)
 
 
 def perform_command(options, handler, command_options):
-	command = PSSyncCommand()
-	handler(command, options, command_options)
+    command = PSSyncCommand()
+    handler(command, options, command_options)
 
 
 class PSSyncCommand(object):
-	"""Process PeopleSoft sync messages into Kafka topics.
+    """Process PeopleSoft sync messages into Kafka topics.
 
-	Usage:
-	  pssync [options] [COMMAND] [ARGS...]
-	  pssync -h|--help
+    Usage:
+      pssync [options] [COMMAND] [ARGS...]
+      pssync -h|--help
 
-	Options:
-	  -z, --zookeeper HOST          Zookeeper service discoveryhost [default: zookeeper:2181]
-	  -k, --kafka HOSTS             Kafka broker hosts, in lieu of zookeeper [default: kafka:9092]
-	  -r, --schema-registry URL     Avro schema registry host [default: schema-registry:80]
-	  -p, --topic-prefix PREFIX     String to prepend to all topic names
+    Options:
+      -z, --zookeeper HOST          Zookeeper service discoveryhost [default: zookeeper:2181]
+      -k, --kafka HOSTS             Kafka broker hosts, in lieu of zookeeper [default: kafka:9092]
+      -r, --schema-registry URL     Avro schema registry host [default: schema-registry:80]
+      -p, --topic-prefix PREFIX     String to prepend to all topic names
 
-	Commands:
-	  collect            Collect PeopleSoft sync messages
-	  config             Validate and view the collector config
-	  parse              Parse sync message streams into record streams
-	"""
+    Commands:
+      collect            Collect PeopleSoft sync messages
+      config             Validate and view the collector config
+      parse              Parse sync message streams into record streams
+    """
 
-	def collect(self, options, command_options):
-		"""Collect PeopleSoft sync and fullsync messages.
+    def collect(self, options, command_options):
+        """Collect PeopleSoft sync and fullsync messages.
 
-		Usage: collect [options]
+        Usage: collect [options]
 
-		Options:
-		  --port PORT                Port to listen to messages on [default: 8000]
-		  --sender-name NAMES        Accepted values for the From header
-		  --recipient-name NAMES     Accepted values for the To header
-		  --message-name NAMES       Accepted values for the MessageName header
-		  --producer-topic TOPIC     Produce to a specific Kafka topic, otherwise
-		                             messages are sent to topics by message name
-		"""
-		
+        Options:
+          --port PORT                Port to listen to messages on [default: 8000]
+          --sender-name NAMES        Accepted values for the From header
+          --recipient-name NAMES     Accepted values for the To header
+          --message-name NAMES       Accepted values for the MessageName header
+          --producer-topic TOPIC     Produce to a specific Kafka topic, otherwise
+                                     messages are sent to topics by message name
+        """
+        
 
-		site = server.Site(PSSyncCollector())
-		endpoint = endpoints.TCP4ServerEndpoint(reactor, 8080)
-		endpoint.listen(site)
-		reactor.run()
+        site = server.Site(PSSyncCollector())
+        endpoint = endpoints.TCP4ServerEndpoint(reactor, 8080)
+        endpoint.listen(site)
+        reactor.run()
 
-	def config(self, options, command_options):
-		"""Validate and view the collector config.
+    def config(self, options, command_options):
+        """Validate and view the collector config.
 
-		Usage: config
-		"""
-		pass
+        Usage: config
+        """
+        pass
 
-	def parse(self, options, command_options):
-		"""Parse sync message streams into record streams.
+    def parse(self, options, command_options):
+        """Parse sync message streams into record streams.
 
-		Usage: parse [options]
+        Usage: parse [options]
 
-		Options:
-		  --source-topic NAME        Topic to consume sync messages from
-		  --destination-topic NAME   Topic to produce record messages to, defaults
-		                             to a topic based on the consumed message name
-		"""
-		pass
+        Options:
+          --source-topic NAME        Topic to consume sync messages from
+          --destination-topic NAME   Topic to produce record messages to, defaults
+                                     to a topic based on the consumed message name
+        """
+        pass

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -58,6 +58,7 @@ class PSSyncCommand(object):
 	Options:
 	  -b, --broker BROKER_HOSTS     Comma-separated list of Kafka broker hosts [default: kafka:9092]
 	  -r, --registry REGISTRY_HOST  URL of the service where Avro schemas are registered
+	  -z, --zookeeper HOST          Zookeeper host [default: zookeeper:2181]
 	  -p, --topic-prefix PREFIX     String to prepend to all topic names
 
 	Commands:

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -12,3 +12,11 @@ class PSSyncCollector(resource.Resource):
         print(request.getAllHeaders())
         print(request.content.read())
         return '{"status":"POST ok"}'.encode('utf-8')
+
+
+def collect(producer, topic=None, port=8000, senders=None, recipients=None, message_names=None):
+    collector = PSSyncCollector()
+    site = server.Site(collector)
+    endpoint = endpoints.TCP4ServerEndpoint(reactor, port)
+    endpoint.listen(site)
+    reactor.run()

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -58,18 +58,12 @@ class PSSyncCollector(resource.Resource):
 
 
 def collect(producer, topic=None, port=8000, senders=None, recipients=None, message_names=None):
-    def header_in_list(request, key, values):
-        header = request.getHeader(key.encode('iso-8859-1'))
-        if header:
-            header = header.decode('iso-8859-1')
-        return header in values
-    
     def authorize_request(request):
-        if senders and not header_in_list(request, 'To', senders):
+        if senders and not request.getHeader('To') in senders:
             return False
-        if recipients and not header_in_list(request, 'From', recipients):
+        if recipients and not request.getHeader('From') in senders:
             return False
-        if message_names and not header_in_list(request, 'MessageName', message_names):
+        if message_names and request.getHeader('MessageName') in senders:
             return False
         return True
 

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -18,6 +18,6 @@ class PSSyncCollector(resource.Resource):
 def collect(producer, topic=None, port=8000, senders=None, recipients=None, message_names=None):
     collector = PSSyncCollector()
     site = server.Site(collector)
-    endpoint = endpoints.TCP4ServerEndpoint(reactor, port)
+    endpoint = endpoints.TCP4ServerEndpoint(reactor, int(port))
     endpoint.listen(site)
     reactor.run()

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -11,10 +11,11 @@ class PSSyncCollector(resource.Resource):
 
     isLeaf = True
 
-    def __init__(self, producer, topic=None):
+    def __init__(self, producer, topic=None, authorize_f=None):
         super().__init__()
         self.producer = producer
         self.topic = topic
+        self.authorize_f = authorize_f
 
     def render_GET(self, request):
         return '{"status":"GET ok"}'.encode('utf-8')
@@ -27,6 +28,10 @@ class PSSyncCollector(resource.Resource):
         The following URL describes the PeopleSoft Rowset-Based Message Format.
         http://docs.oracle.com/cd/E66686_01/pt855pbr1/eng/pt/tibr/concept_PeopleSoftRowset-BasedMessageFormat-0764fb.html
         """
+        if self.authorize_f and not self.authorize_f(request):
+            request.setResponseCode(403, message='Forbidden')
+            return 'Message not accepted by collector.'.encode('utf-8')
+
         psft_message_name = None
         field_types = None
 

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -20,4 +20,5 @@ def collect(producer, topic=None, port=8000, senders=None, recipients=None, mess
     site = server.Site(collector)
     endpoint = endpoints.TCP4ServerEndpoint(reactor, int(port))
     endpoint.listen(site)
+    print(f'Listening for connections on port {port}')
     reactor.run()

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -11,6 +11,11 @@ class PSSyncCollector(resource.Resource):
 
     isLeaf = True
 
+    def __init__(self, producer, topic=None):
+        super().__init__()
+        self.producer = producer
+        self.topic = topic
+
     def render_GET(self, request):
         return '{"status":"GET ok"}'.encode('utf-8')
 
@@ -45,7 +50,7 @@ class PSSyncCollector(resource.Resource):
 
 
 def collect(producer, topic=None, port=8000, senders=None, recipients=None, message_names=None):
-    collector = PSSyncCollector()
+    collector = PSSyncCollector(producer, topic=topic)
     site = server.Site(collector)
     endpoint = endpoints.TCP4ServerEndpoint(reactor, int(port))
     endpoint.listen(site)

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -55,7 +55,22 @@ class PSSyncCollector(resource.Resource):
 
 
 def collect(producer, topic=None, port=8000, senders=None, recipients=None, message_names=None):
-    collector = PSSyncCollector(producer, topic=topic)
+    def header_in_list(request, key, values):
+        header = request.getHeader(key.encode('iso-8859-1'))
+        if header:
+            header = header.decode('iso-8859-1')
+        return header in values
+    
+    def authorize_request(request):
+        if senders and not header_in_list(request, 'To', senders):
+            return False
+        if recipients and not header_in_list(request, 'From', recipients):
+            return False
+        if message_names and not header_in_list(request, 'MessageName', message_names):
+            return False
+        return True
+
+    collector = PSSyncCollector(producer, topic=topic, authorize_f=authorize_request)
     site = server.Site(collector)
     endpoint = endpoints.TCP4ServerEndpoint(reactor, int(port))
     endpoint.listen(site)

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -1,6 +1,11 @@
+import json
+
+from xml.etree import ElementTree
+
 from twisted.internet import endpoints, reactor
 from twisted.web import resource, server
 
+from .utils import element_to_obj
 
 class PSSyncCollector(resource.Resource):
 
@@ -10,8 +15,25 @@ class PSSyncCollector(resource.Resource):
         return '{"status":"GET ok"}'.encode('utf-8')
 
     def render_POST(self, request):
-        print(request.getAllHeaders())
-        print(request.content.read())
+        """Decode PeopleSoft rowset-based messages into transactions, and produce Kafka
+        messages for each transaction. PeopleSoft is expected to POST messages as events
+        occur via SYNC and FULLSYNC services.
+
+        The following URL describes the PeopleSoft Rowset-Based Message Format.
+        http://docs.oracle.com/cd/E66686_01/pt855pbr1/eng/pt/tibr/concept_PeopleSoftRowset-BasedMessageFormat-0764fb.html
+        """
+        psft_message_name = None
+        field_types = None
+
+        # Parse the root element for the PeopleSoft message name and FieldTypes
+        request.content.seek(0,0)
+        for event, e in ElementTree.iterparse(request.content, events=('start', 'end')):
+            if event == 'start' and psft_message_name is None:
+                psft_message_name = e.tag
+            elif event == 'end' and e.tag == 'FieldTypes':
+                field_types = element_to_obj(e, value_f=field_type)
+                break
+
         return '{"status":"POST ok"}'.encode('utf-8')
 
 
@@ -22,3 +44,8 @@ def collect(producer, topic=None, port=8000, senders=None, recipients=None, mess
     endpoint.listen(site)
     print(f'Listening for connections on port {port}')
     reactor.run()
+
+
+def field_type(element):
+    assert('type' in element.attrib)
+    return element.attrib.get('type')

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -32,6 +32,9 @@ class PSSyncCollector(resource.Resource):
             request.setResponseCode(403, message='Forbidden')
             return 'Message not accepted by collector.'.encode('utf-8')
 
+        assert(request.getHeader('DataChunk') == '1'.encode('iso-8859-1'))
+        assert(request.getHeader('DataChunkCount') == '1'.encode('iso-8859-1'))
+
         psft_message_name = None
         field_types = None
 

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -1,4 +1,5 @@
-from twisted.web import resource
+from twisted.internet import endpoints, reactor
+from twisted.web import resource, server
 
 
 class PSSyncCollector(resource.Resource):

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -9,6 +9,7 @@ from twisted.web import resource, server
 
 from .utils import element_to_obj
 
+
 class PSSyncCollector(resource.Resource):
 
     isLeaf = True

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -3,12 +3,12 @@ from twisted.web import resource
 
 class PSSyncCollector(resource.Resource):
 
-	isLeaf = True
+    isLeaf = True
 
-	def render_GET(self, request):
-		return '{"status":"GET ok"}'.encode('utf-8')
+    def render_GET(self, request):
+        return '{"status":"GET ok"}'.encode('utf-8')
 
-	def render_POST(self, request):
-		print(request.getAllHeaders())
-		print(request.content.read())
-		return '{"status":"POST ok"}'.encode('utf-8')
+    def render_POST(self, request):
+        print(request.getAllHeaders())
+        print(request.content.read())
+        return '{"status":"POST ok"}'.encode('utf-8')

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -32,8 +32,8 @@ class PSSyncCollector(resource.Resource):
             request.setResponseCode(403, message='Forbidden')
             return 'Message not accepted by collector.'.encode('utf-8')
 
-        assert(request.getHeader('DataChunk') == '1'.encode('iso-8859-1'))
-        assert(request.getHeader('DataChunkCount') == '1'.encode('iso-8859-1'))
+        assert(request.getHeader('DataChunk') == '1')
+        assert(request.getHeader('DataChunkCount') == '1')
 
         psft_message_name = None
         field_types = None

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -34,6 +34,13 @@ class PSSyncCollector(resource.Resource):
                 field_types = element_to_obj(e, value_f=field_type)
                 break
 
+        # Rescan for transactions, removing read elements to reduce memory usage
+        request.content.seek(0,0)
+        for event, e in ElementTree.iterparse(request.content, events=('end',)):
+            if e.tag == 'Transaction':
+                print(json.dumps(element_to_obj(e), indent=4))
+                e.clear()
+
         return '{"status":"POST ok"}'.encode('utf-8')
 
 

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -37,6 +37,10 @@ class PSSyncCollector(resource.Resource):
 
         psft_message_name = None
         field_types = None
+        
+        transaction_id = request.getHeader('TransactionID')
+        transaction_id_bytes = transaction_id.encode('utf-8')
+        orig_time_stamp = request.getHeader('OrigTimeStamp')
 
         # Parse the root element for the PeopleSoft message name and FieldTypes
         request.content.seek(0,0)

--- a/pssync/utils.py
+++ b/pssync/utils.py
@@ -1,0 +1,19 @@
+def element_text(element):
+    value = element.text
+    if value:
+        value.strip()
+    return value
+
+
+def element_to_obj(element, map_class=dict, value_f=element_text, wrap_value=True):
+    value = None
+    
+    if len(element) > 0:
+        child_values = map(lambda e: (e.tag, element_to_obj(e, wrap_value=False)), element)
+        value = map_class(child_values)
+    else:
+        value = value_f(element)
+
+    if wrap_value:
+        value = {element.tag: value}
+    return value

--- a/pssync/utils.py
+++ b/pssync/utils.py
@@ -9,7 +9,7 @@ def element_to_obj(element, map_class=dict, value_f=element_text, wrap_value=Tru
     value = None
     
     if len(element) > 0:
-        child_values = map(lambda e: (e.tag, element_to_obj(e, wrap_value=False)), element)
+        child_values = map(lambda e: (e.tag, element_to_obj(e, map_class=map_class ,value_f=value_f, wrap_value=False)), element)
         value = map_class(child_values)
     else:
         value = value_f(element)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 docopt==0.6.2
 Twisted==16.6.0
 git+https://github.com/confluentinc/confluent-kafka-python.git#egg=confluent-kafka[avro]
+confluent-schema-registry-client==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 docopt==0.6.2
+pytz==2016.10
 Twisted==16.6.0
 git+https://github.com/confluentinc/confluent-kafka-python.git#egg=confluent-kafka[avro]
 confluent-schema-registry-client==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ docopt==0.6.2
 Twisted==16.6.0
 git+https://github.com/confluentinc/confluent-kafka-python.git#egg=confluent-kafka[avro]
 confluent-schema-registry-client==1.1.0
+kazoo==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docopt==0.6.2
 Twisted==16.6.0
+git+https://github.com/confluentinc/confluent-kafka-python.git#egg=confluent-kafka[avro]

--- a/setup.py
+++ b/setup.py
@@ -6,19 +6,19 @@ from setuptools import setup
 
 
 install_requires = [
-	'docopt >= 0.6.2',
-	'Twisted >= 16.6.0'
+    'docopt >= 0.6.2',
+    'Twisted >= 16.6.0'
 ]
 
 
 setup(
-	name='pssync',
-	description='Process PeopleSoft sync messages into Kafka topics',
-	author='King Chung Huang',
-	packages=find_packages(),
-	install_requires=install_requires,
-	entry_points="""
-	[console_scripts]
-	pssync=pssync.cli.main:main
-	"""
+    name='pssync',
+    description='Process PeopleSoft sync messages into Kafka topics',
+    author='King Chung Huang',
+    packages=find_packages(),
+    install_requires=install_requires,
+    entry_points="""
+    [console_scripts]
+    pssync=pssync.cli.main:main
+    """
 )


### PR DESCRIPTION
The collect command listens for HTTP POST requests from PeopleSoft and parses PeopleSoft rowset-based messages, producing Kafka messages for each transaction contained within. The accepted PeopleSoft messages can be controlled by specifying allow senders, recipients, and message names (corresponding to the `To`, `From`, and `MessageName` headers).

This implementation current produces string keys and JSON values, not Avro encoded keys and values. Avro support will be implemented later.