### PR TITLE
Options refinements

### DIFF
--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import os
 import sys
 
 from confluent_kafka import Consumer, Producer
@@ -127,7 +128,12 @@ class PSSyncCommand(object):
 
 
 def consolidated_options(options, command_options):
-    return {**options, **command_options}
+    environ_option_keys = ((k, 'PSSYNC_' + k.lstrip('-').replace('-', '_').upper())
+                           for k in (*options.keys(), *command_options.keys()))
+    environ_options = {option_key: os.environ[environ_key]
+                       for option_key, environ_key in environ_option_keys
+                       if environ_key in os.environ}
+    return {**environ_options, **options, **command_options}
 
 
 def kafka_config_from_options(options):

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -82,8 +82,7 @@ class PSSyncCommand(object):
           --accept-from NAMES         Accepted values for the From header
           --accept-to NAMES           Accepted values for the To header
           --accept-messagename NAMES  Accepted values for the MessageName header
-          --topic TOPIC               Produce to a specific Kafka topic, otherwise
-                                      messages are sent to topics by message name
+          --sink-topic TOPIC          Topic to write transactions to [default: ps-transactions]
         """
         config = kafka_config_from_options(options)
         producer = Producer(config)
@@ -107,13 +106,12 @@ class PSSyncCommand(object):
         """Parse transaction messages into record streams.
 
         Usage: publish [--source-topic=<arg>]...
-                       [--destination-topic=<arg>]
+                       [--sink-topic=<arg>]
                        [options]
 
         Options:
-          --source-topic NAME        Topics to consume sync messages from
-          --destination-topic NAME   Topic to produce record messages to, defaults
-                                     to a topic based on the consumed message name
+          --source-topic NAME        Topics to consume transactions from [default: ps-transactions]
+          --sink-topic NAME          Topic to write records to, defaults to the record type
           --consumer-group GROUP     Kafka consumer group name [default: pssync]
         """
         config = kafka_config_from_options(options)
@@ -124,7 +122,7 @@ class PSSyncCommand(object):
           consumer,
           producer,
           source_topics=options['--source-topic'],
-          destination_topic=options['--destination-topic'])
+          destination_topic=options['--sink-topic'])
 
 
 def consolidated_options(options, command_options):

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -75,15 +75,15 @@ class PSSyncCommand(object):
         Usage: collect [--port=<arg>] [--topic=<arg>]
                        [--accept-from=<arg>]...
                        [--accept-to=<arg>]...
-                       [--messages=<arg>]...
+                       [--accept-messagename=<arg>]...
 
         Options:
-          --port PORT           Port to listen to messages on [default: 8000]
-          --accept-from NAMES   Accepted values for the From header
-          --accept-to NAMES     Accepted values for the To header
-          --messages NAMES      Accepted values for the MessageName header
-          --topic TOPIC         Produce to a specific Kafka topic, otherwise
-                                messages are sent to topics by message name
+          --port PORT                 Port to listen to messages on [default: 8000]
+          --accept-from NAMES         Accepted values for the From header
+          --accept-to NAMES           Accepted values for the To header
+          --accept-messagename NAMES  Accepted values for the MessageName header
+          --topic TOPIC               Produce to a specific Kafka topic, otherwise
+                                      messages are sent to topics by message name
         """
         config = kafka_config_from_options(options)
         producer = Producer(config)
@@ -94,7 +94,7 @@ class PSSyncCommand(object):
           port=int(options['--port']),
           senders=options['--accept-from'],
           recipients=options['--accept-to'],
-          message_names=options['--messages'])
+          message_names=options['--accept-messagename'])
 
     def config(self, options):
         """Validate and view the collector config.

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -58,7 +58,7 @@ class PSSyncCommand(object):
 
     Options:
       -k, --kafka HOSTS             Kafka bootstrap hosts [default: kafka:9092]
-      -r, --schema-registry URL     Avro schema registry host [default: http://schema-registry:80]
+      -r, --schema-registry URL     Avro schema registry url [default: http://schema-registry:80]
       -p, --topic-prefix PREFIX     String to prepend to all topic names
 
     Commands:

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -57,7 +57,7 @@ class PSSyncCommand(object):
       pssync -h|--help
 
     Options:
-      -k, --kafka HOSTS             Kafka brokers [default: kafka:9092]
+      -k, --kafka HOSTS             Kafka bootstrap hosts [default: kafka:9092]
       -r, --schema-registry URL     Avro schema registry host [default: http://schema-registry:80]
       -p, --topic-prefix PREFIX     String to prepend to all topic names
 

--- a/pssync/cli/main.py
+++ b/pssync/cli/main.py
@@ -73,14 +73,14 @@ class PSSyncCommand(object):
         """Collect PeopleSoft sync and fullsync messages.
 
         Usage: collect [--port=<arg>] [--topic=<arg>]
-                       [--senders=<arg>]...
-                       [--recipients=<arg>]...
+                       [--accept-from=<arg>]...
+                       [--accept-to=<arg>]...
                        [--messages=<arg>]...
 
         Options:
           --port PORT           Port to listen to messages on [default: 8000]
-          --senders NAMES       Accepted values for the From header
-          --recipients NAMES    Accepted values for the To header
+          --accept-from NAMES   Accepted values for the From header
+          --accept-to NAMES     Accepted values for the To header
           --messages NAMES      Accepted values for the MessageName header
           --topic TOPIC         Produce to a specific Kafka topic, otherwise
                                 messages are sent to topics by message name
@@ -92,8 +92,8 @@ class PSSyncCommand(object):
           producer,
           topic=options['--topic'],
           port=int(options['--port']),
-          senders=options['--senders'],
-          recipients=options['--recipients'],
+          senders=options['--accept-from'],
+          recipients=options['--accept-to'],
           message_names=options['--messages'])
 
     def config(self, options):


### PR DESCRIPTION
Rename some options to better align with terminology in Kafka Connect and Kafka Streams. Also, allow the use of environment variables to set options, in lieu of command line arguments.