### PR TITLE
Maintain XML data for transaction messages

### DIFF
--- a/.stack.yml
+++ b/.stack.yml
@@ -44,7 +44,7 @@ services:
       traefik.frontend.rule: "Host:${COMPOSE_PROJECT_NAME}.rms-dev.ucalgary.ca,PathPrefix:/pssync"
       traefik.frontend.entryPoints: http,https
       traefik.protocol: http
-      traefik.port: 8000
+      traefik.port: '8000'
       traefik.docker.network: traefik_rms-dev
     deploy:
       labels:
@@ -52,7 +52,7 @@ services:
         traefik.frontend.rule: "Host:${COMPOSE_PROJECT_NAME}.rms-dev.ucalgary.ca,PathPrefix:/pssync"
         traefik.frontend.entryPoints: http,https
         traefik.protocol: http
-        traefik.port: 8000
+        traefik.port: '8000'
         traefik.docker.network: traefik_rms-dev
     networks:
       - streaming
@@ -78,7 +78,7 @@ services:
       traefik.frontend.rule: "Host:${COMPOSE_PROJECT_NAME}.rms-dev.ucalgary.ca"
       traefik.frontend.entryPoints: http
       traefik.protocol: http
-      traefik.port: 8000
+      traefik.port: '8000'
       traefik.docker.network: traefik_rms-dev
     deploy:
       labels:
@@ -86,7 +86,7 @@ services:
         traefik.frontend.rule: "Host:${COMPOSE_PROJECT_NAME}.rms-dev.ucalgary.ca"
         traefik.frontend.entryPoints: http
         traefik.protocol: http
-        traefik.port: 8000
+        traefik.port: '8000'
         traefik.docker.network: traefik_rms-dev
     networks:
       - streaming

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -42,7 +42,6 @@ class PSSyncCollector(resource.Resource):
         field_types = None
 
         transaction_id = request.getHeader('TransactionID')
-        transaction_id_bytes = transaction_id.encode('utf-8')
         orig_time_stamp = request.getHeader('OrigTimeStamp')
 
         # Parse the root element for the PeopleSoft message name and FieldTypes
@@ -68,7 +67,7 @@ class PSSyncCollector(resource.Resource):
                     'Transaction': transaction
                 }
                 message_str = json.dumps(message)
-                self.producer.produce(self.topic, message_str, transaction_id_bytes)
+                self.producer.produce(self.topic, message_str, transaction_id)
                 e.clear()
                 transaction_index += 1
         self.producer.flush()

--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -59,7 +59,7 @@ class PSSyncCollector(resource.Resource):
         request.content.seek(0, 0)
         for event, e in ElementTree.iterparse(request.content, events=('end',)):
             if e.tag == 'Transaction':
-                transaction = element_to_obj(e, wrap_value=False)
+                transaction = ElementTree.tostring(e, encoding='unicode')
                 message = {
                     'TransactionID': transaction_id,
                     'TransactionIndex': transaction_index,
@@ -67,8 +67,8 @@ class PSSyncCollector(resource.Resource):
                     'CollectTimeStamp': datetime.now(pytz.utc).astimezone().isoformat(),
                     'Transaction': transaction
                 }
-                message_bytes = json.dumps(message).encode('utf-8')
-                self.producer.produce(self.topic, message_bytes, transaction_id_bytes)
+                message_str = json.dumps(message)
+                self.producer.produce(self.topic, message_str, transaction_id_bytes)
                 e.clear()
                 transaction_index += 1
         self.producer.flush()

--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -1,11 +1,12 @@
 import json
 import pkg_resources
-
 from difflib import SequenceMatcher
+from xml.etree import ElementTree
 
 import yaml
-
 from confluent_kafka import KafkaError
+
+from .utils import element_to_obj
 
 
 key_attributes_by_record_name = yaml.load(
@@ -47,6 +48,10 @@ class PSSyncPublisher(object):
         self.consumer.close()
 
     def messages_from_transaction(self, transaction, key_serde=json.dumps, value_serde=json.dumps):
+        transaction['Transaction'] = element_to_obj(
+            ElementTree.fromstring(transaction['Transaction']), wrap_value=False)
+        print(transaction)
+
         audit_actn = transaction['Transaction']['PSCAMA']['AUDIT_ACTN']
         assert(audit_actn in ('A', 'C', 'D'))
 


### PR DESCRIPTION
Keep the original XML data for transaction messages instead of converting to native objects. This reduces the amount of processing that occurs during collection, and also eliminates a potential source of runtime errors. It is important for the collector to be reliable and not drop messages.