### PR TITLE
Switch to ujson module

### DIFF
--- a/pssync/collector.py
+++ b/pssync/collector.py
@@ -1,4 +1,4 @@
-import json
+import ujson as json
 import pytz
 
 from datetime import datetime

--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -1,4 +1,4 @@
-import json
+import ujson as json
 import pkg_resources
 from difflib import SequenceMatcher
 from xml.etree import ElementTree

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Twisted==16.6.0
 confluent-kafka[avro]==0.9.4
 confluent-schema-registry-client==1.1.0
 kazoo==2.2.1
+ujson==1.35


### PR DESCRIPTION
Change from the built-in json module to the ujson module for json encoding and decoding. It is faster for the use cases here.