### PR TITLE
Return if audit_actn not in A, C, D

### DIFF
--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -50,10 +50,11 @@ class PSSyncPublisher(object):
     def messages_from_transaction(self, transaction, key_serde=json.dumps, value_serde=json.dumps):
         transaction['Transaction'] = element_to_obj(
             ElementTree.fromstring(transaction['Transaction']), wrap_value=False)
-        print(transaction)
 
         audit_actn = transaction['Transaction']['PSCAMA']['AUDIT_ACTN']
-        assert(audit_actn in ('A', 'C', 'D'))
+        if audit_actn not in ('A', 'C', 'D'):
+            print(transaction)
+            return
 
         for record_type, record_data in transaction['Transaction'].items():
             if record_type == 'PSCAMA':


### PR DESCRIPTION
If the value of audit_actn is not one of A, C, or D, stop yielding
messages. It seems FULLSYNC transactions can sometimes contain empty
messages.

Resolves #13.