### PR TITLE
Termination handlers for publisher

### DIFF
--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -53,6 +53,7 @@ class PSSyncPublisher(object):
     def terminate(self):
         log.info('Terminating')
         self.consumer.close()
+        self.producer.flush()
 
     def messages_from_transaction(self, transaction, key_serde=json.dumps, value_serde=json.dumps):
         transaction['Transaction'] = element_to_obj(

--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -48,6 +48,9 @@ class PSSyncPublisher(object):
                 print(message.error())
                 self.running = False
 
+        self.terminate()
+
+    def terminate(self):
         log.info('Terminating')
         self.consumer.close()
 

--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -1,5 +1,6 @@
 import logging
 import pkg_resources
+import sys
 from difflib import SequenceMatcher
 from xml.etree import ElementTree
 
@@ -54,6 +55,7 @@ class PSSyncPublisher(object):
         log.info('Terminating')
         self.consumer.close()
         self.producer.flush()
+        sys.exit(0)
 
     def messages_from_transaction(self, transaction, key_serde=json.dumps, value_serde=json.dumps):
         transaction['Transaction'] = element_to_obj(

--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -40,7 +40,7 @@ class PSSyncPublisher(object):
         self.consumer.subscribe(self.source_topics)
 
         while self.running:
-            message = self.consumer.poll(timeout=30)
+            message = self.consumer.poll(timeout=5)
 
             if not message:
                 continue

--- a/pssync/publisher.py
+++ b/pssync/publisher.py
@@ -1,5 +1,6 @@
 import logging
 import pkg_resources
+import signal
 import sys
 from difflib import SequenceMatcher
 from xml.etree import ElementTree
@@ -33,6 +34,9 @@ class PSSyncPublisher(object):
         messages representing a stream of PeopleSoft rows organized
         by record name.
         '''
+        signal.signal(signal.SIGINT, self.terminate)
+        signal.signal(signal.SIGTERM, self.terminate)
+
         self.consumer.subscribe(self.source_topics)
 
         while self.running:


### PR DESCRIPTION
Add SIGINT and SIGTERM handlers for the publisher. Also flush the Kafka producer before terminating to help ensure that queued messages make it to the broker.