### PR TITLE
Update review stack for Kafka 0.10.2.0 and local dev

### DIFF
--- a/.stack-dev.yml
+++ b/.stack-dev.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  kafka-topics-ui:
+    ports:
+      - 8080:8000
+
+  pssync-collector:
+    ports:
+      - 8000:8000

--- a/.stack.yml
+++ b/.stack.yml
@@ -8,7 +8,7 @@ services:
       - streaming
 
   kafka:
-    image: ucalgary/kafka:0.10.1.1
+    image: ucalgary/kafka:0.10.2.0
     hostname: kafka
     networks:
       - streaming

--- a/.stack.yml
+++ b/.stack.yml
@@ -16,7 +16,7 @@ services:
       - zookeeper
 
   kafka-rest:
-    image: ucalgary/kafka-rest:3.1.1
+    image: ucalgary/kafka-rest:3.2.0
     hostname: kafka-rest
     networks:
       - streaming
@@ -25,7 +25,7 @@ services:
       - kafka
 
   schema-registry:
-    image: ucalgary/schema-registry:3.1.1
+    image: ucalgary/schema-registry:3.2.0
     hostname: schema-registry
     networks:
       - streaming


### PR DESCRIPTION
Update Kafka to 0.10.2.0, and Schema Registry and Kafka REST Proxy to 3.2.0.

Also publish ports on the kafka-topics-ui and pssync-collector services for development use.