### PR TITLE
Implement support for topic name prefixes

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,3 @@
 COMPOSE_PROJECT_NAME=ps-stream
 COMPOSE_FILE=.stack.yml:.stack-dev.yml
 IMAGE_DIGEST=ps-stream
-PSSTREAM_TRANSACTIONS_TOPIC=ps-transactions
-PSSTREAM_CONSUMER_GROUP=ps-stream

--- a/.stack.yml
+++ b/.stack.yml
@@ -37,7 +37,7 @@ services:
     image: $IMAGE_DIGEST
     command:
       - collect
-      - --topic
+      - --target-topic
       - $PSSTREAM_TRANSACTIONS_TOPIC
     labels:
       traefik.tags: rms-dev

--- a/.stack.yml
+++ b/.stack.yml
@@ -37,8 +37,6 @@ services:
     image: $IMAGE_DIGEST
     command:
       - collect
-      - --target-topic
-      - $PSSTREAM_TRANSACTIONS_TOPIC
     labels:
       traefik.tags: rms-dev
       traefik.frontend.rule: "Host:${COMPOSE_PROJECT_NAME}.rms-dev.ucalgary.ca;PathPrefix:/pssync"
@@ -62,10 +60,6 @@ services:
     image: $IMAGE_DIGEST
     command:
       - publish
-      - --source-topic
-      - $PSSTREAM_TRANSACTIONS_TOPIC
-      - --consumer-group
-      - $PSSTREAM_CONSUMER_GROUP
     networks:
       - streaming
 

--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -92,7 +92,7 @@ class PSStreamCommand(object):
 
         collector.collect(
           producer,
-          topic=options['--target-topic'],
+          topic=prefix_topics(options['--target-prefix'], (options['--target-topic'],)),
           port=int(options['--port']),
           senders=options['--accept-from'],
           recipients=options['--accept-to'],
@@ -126,8 +126,8 @@ class PSStreamCommand(object):
         publisher.publish(
           consumer,
           producer,
-          source_topics=options['--source-topic'],
-          destination_topic=options['--target-topic'])
+          source_topics=prefix_topics(options['--source-prefix'], options['--source-topic']),
+          destination_topic=prefix_topics(options['--target-prefix'], options['--target-topic']))
 
 
 def consolidated_options(options, command_options):
@@ -148,3 +148,12 @@ def kafka_config_from_options(options):
         config['group.id'] = options['--consumer-group']
 
     return config
+
+
+def prefix_topics(prefix, topics):
+    if prefix:
+        if not isinstance(topics, basestring):
+            return ['%s.%s'.format(prefix, topic) for topic in topics]
+        else:
+            return '%s.%s'.format(prefix, topics)
+    return topics

--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -155,7 +155,7 @@ def prefix_topics(prefix, topics):
         return topics
     if prefix:
         if not isinstance(topics, str):
-            return ['%s.%s'.format(prefix, topic) for topic in topics]
+            return [f'{prefix}.{topic}' for topic in topics]
         else:
-            return '%s.%s'.format(prefix, topics)
+            return f'{prefix}.{topics}'
     return topics

--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -154,7 +154,7 @@ def prefix_topics(prefix, topics):
     if not topics:
         return topics
     if prefix:
-        if not isinstance(topics, basestring):
+        if not isinstance(topics, str):
             return ['%s.%s'.format(prefix, topic) for topic in topics]
         else:
             return '%s.%s'.format(prefix, topics)

--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -55,8 +55,7 @@ class PSStreamCommand(object):
     """Process PeopleSoft sync messages into Kafka topics.
 
     Usage:
-      ps-stream [--kafka=<arg>]... [--schema-registry=<arg>]
-                [--zookeeper=<arg>] [--topic-prefix=<arg>]
+      ps-stream [--kafka=<arg>]... [--schema-registry=<arg>] [--zookeeper=<arg>]
                 [--verbose]
                 [COMMAND] [ARGS...]
       ps-stream -h|--help
@@ -64,7 +63,6 @@ class PSStreamCommand(object):
     Options:
       -k, --kafka HOSTS             Kafka bootstrap hosts [default: kafka:9092]
       -r, --schema-registry URL     Avro schema registry url [default: http://schema-registry:80]
-      -p, --topic-prefix PREFIX     String to prepend to all topic names
       --verbose                     Show more output
 
     Commands:
@@ -76,7 +74,7 @@ class PSStreamCommand(object):
     def collect(self, options):
         """Collect PeopleSoft sync and fullsync messages.
 
-        Usage: collect [--port=<arg>] [--topic=<arg>]
+        Usage: collect [--port=<arg>] [--target-prefix=<arg>] [--target-topic=<arg>]
                        [--accept-from=<arg>]...
                        [--accept-to=<arg>]...
                        [--accept-messagename=<arg>]...
@@ -86,7 +84,8 @@ class PSStreamCommand(object):
           --accept-from NAMES         Accepted values for the From header
           --accept-to NAMES           Accepted values for the To header
           --accept-messagename NAMES  Accepted values for the MessageName header
-          --target-topic TOPIC        Topic to write transactions to [default: ps-transactions]
+          --target-prefix PREFIX      Prefix name for target topic [default: ps]
+          --target-topic TOPIC        Topic to write transactions to [default: transactions]
         """
         config = kafka_config_from_options(options)
         producer = Producer(config)
@@ -109,12 +108,14 @@ class PSStreamCommand(object):
     def publish(self, options):
         """Parse transaction messages into record streams.
 
-        Usage: publish [--source-topic=<arg>]...
-                       [--target-topic=<arg>]
+        Usage: publish [--source-prefix=<arg>] [--source-topic=<arg>]...
+                       [--target-prefix=<arg>] [--target-topic=<arg>]
                        [options]
 
         Options:
-          --source-topic NAME        Topics to consume transactions from [default: ps-transactions]
+          --source-prefix PREFIX     Prefix string for source topics [default: ps]
+          --source-topic NAME        Topics to consume transactions from [default: transactions]
+          --target-prefix PREFIX     Prefix name for target topics [default: ps]
           --target-topic NAME        Topic to write records to, defaults to the record type
           --consumer-group GROUP     Kafka consumer group name [default: ps-stream]
         """

--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -127,7 +127,7 @@ class PSStreamCommand(object):
           consumer,
           producer,
           source_topics=prefix_topics(options['--source-prefix'], options['--source-topic']),
-          destination_topic=prefix_topics(options['--target-prefix'], options['--target-topic']))
+          target_topic=prefix_topics(options['--target-prefix'], options['--target-topic']))
 
 
 def consolidated_options(options, command_options):

--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -86,14 +86,14 @@ class PSStreamCommand(object):
           --accept-from NAMES         Accepted values for the From header
           --accept-to NAMES           Accepted values for the To header
           --accept-messagename NAMES  Accepted values for the MessageName header
-          --sink-topic TOPIC          Topic to write transactions to [default: ps-transactions]
+          --target-topic TOPIC        Topic to write transactions to [default: ps-transactions]
         """
         config = kafka_config_from_options(options)
         producer = Producer(config)
 
         collector.collect(
           producer,
-          topic=options['--topic'],
+          topic=options['--target-topic'],
           port=int(options['--port']),
           senders=options['--accept-from'],
           recipients=options['--accept-to'],
@@ -110,12 +110,12 @@ class PSStreamCommand(object):
         """Parse transaction messages into record streams.
 
         Usage: publish [--source-topic=<arg>]...
-                       [--sink-topic=<arg>]
+                       [--target-topic=<arg>]
                        [options]
 
         Options:
           --source-topic NAME        Topics to consume transactions from [default: ps-transactions]
-          --sink-topic NAME          Topic to write records to, defaults to the record type
+          --target-topic NAME        Topic to write records to, defaults to the record type
           --consumer-group GROUP     Kafka consumer group name [default: ps-stream]
         """
         config = kafka_config_from_options(options)
@@ -126,7 +126,7 @@ class PSStreamCommand(object):
           consumer,
           producer,
           source_topics=options['--source-topic'],
-          destination_topic=options['--sink-topic'])
+          destination_topic=options['--target-topic'])
 
 
 def consolidated_options(options, command_options):

--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -151,6 +151,8 @@ def kafka_config_from_options(options):
 
 
 def prefix_topics(prefix, topics):
+    if not topics:
+        return topics
     if prefix:
         if not isinstance(topics, basestring):
             return ['%s.%s'.format(prefix, topic) for topic in topics]

--- a/ps_stream/publisher.py
+++ b/ps_stream/publisher.py
@@ -21,12 +21,12 @@ key_formats_by_record_type = yaml.load(
 
 class PSStreamPublisher(object):
 
-    def __init__(self, consumer, producer, source_topics=None, destination_topic=None):
+    def __init__(self, consumer, producer, source_topics=None, target_topic=None):
         super().__init__()
         self.consumer = consumer
         self.producer = producer
         self.source_topics = source_topics
-        self.destination_topic = destination_topic
+        self.target_topic = target_topic
         self.running = True
 
     def run(self):
@@ -84,7 +84,7 @@ class PSStreamPublisher(object):
             yield topic, key, value
 
     def topic_for_record(self, record_type, record_data):
-        return self.destination_topic or record_type
+        return self.target_topic or record_type
 
     def key_for_record(self, record_type, record_data, guess=False):
         key_format = key_formats_by_record_type.get(record_type, None)
@@ -99,9 +99,9 @@ class PSStreamPublisher(object):
         return key_format and key_format.format(**record_data)
 
 
-def publish(consumer, producer, source_topics=None, destination_topic=None):
+def publish(consumer, producer, source_topics=None, target_topic=None):
     publisher = PSStreamPublisher(
         consumer, producer,
-        source_topics=source_topics, destination_topic=destination_topic)
+        source_topics=source_topics, target_topic=target_topic)
     log.info(f'Reading transactions from {source_topics}')
     publisher.run()


### PR DESCRIPTION
Implement support for prefixing source and target topic names. This helps distinguish groups of topics in Kafka.