### PR TITLE
Drop Avro and Schema Registry support

### DIFF
--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -55,14 +55,13 @@ class PSStreamCommand(object):
     """Process PeopleSoft sync messages into Kafka topics.
 
     Usage:
-      ps-stream [--kafka=<arg>]... [--schema-registry=<arg>] [--zookeeper=<arg>]
+      ps-stream [--kafka=<arg>]...
                 [--verbose]
                 [COMMAND] [ARGS...]
       ps-stream -h|--help
 
     Options:
       -k, --kafka HOSTS             Kafka bootstrap hosts [default: kafka:9092]
-      -r, --schema-registry URL     Avro schema registry url [default: http://schema-registry:80]
       --verbose                     Show more output
 
     Commands:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ install_requires = [
     'PyYAML==3.12',
     'pytz==2016.10',
     'confluent-kafka==0.9.4',
-    'confluent-schema-registry-client==1.1.0',
     'ujson==1.35'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'Twisted==16.6.0',
     'PyYAML==3.12',
     'pytz==2016.10',
-    'confluent-kafka[avro]==0.9.4',
+    'confluent-kafka==0.9.4',
     'confluent-schema-registry-client==1.1.0',
     'ujson==1.35'
 ]


### PR DESCRIPTION
`ps-stream` currently does not make use of Avro encoding or the Schema Registry. Remove references to these until they are needed.

Resolves #21