### PR TITLE
Start reading from smallest offset if there is no committed offset

### DIFF
--- a/ps_stream/cli/main.py
+++ b/ps_stream/cli/main.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 
-from confluent_kafka import Consumer, Producer
 from docopt import docopt
 from inspect import getdoc
 
@@ -87,10 +86,9 @@ class PSStreamCommand(object):
           --target-topic TOPIC        Topic to write transactions to [default: transactions]
         """
         config = kafka_config_from_options(options)
-        producer = Producer(config)
 
         collector.collect(
-          producer,
+          config,
           topic=prefix_topics(options['--target-prefix'], options['--target-topic']),
           port=int(options['--port']),
           senders=options['--accept-from'],
@@ -119,12 +117,9 @@ class PSStreamCommand(object):
           --consumer-group GROUP     Kafka consumer group name [default: ps-stream]
         """
         config = kafka_config_from_options(options)
-        consumer = Consumer(config)
-        producer = Producer(config)
 
         publisher.publish(
-          consumer,
-          producer,
+          config,
           source_topics=prefix_topics(options['--source-prefix'], options['--source-topic']),
           target_topic=prefix_topics(options['--target-prefix'], options['--target-topic']),
           target_prefix=options['--target-prefix'])

--- a/ps_stream/collector.py
+++ b/ps_stream/collector.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from xml.etree import ElementTree
 
 import ujson as json
+from confluent_kafka import Producer
 from twisted.internet import endpoints, reactor
 from twisted.web import resource, server
 
@@ -83,7 +84,7 @@ class PSStreamCollector(resource.Resource):
         return '{"status":"POST ok"}'.encode('utf-8')
 
 
-def collect(producer, topic=None, port=8000, senders=None, recipients=None, message_names=None):
+def collect(config, topic=None, port=8000, senders=None, recipients=None, message_names=None):
     def authorize_request(request):
         if senders and not request.getHeader('To') in senders:
             return False
@@ -93,6 +94,7 @@ def collect(producer, topic=None, port=8000, senders=None, recipients=None, mess
             return False
         return True
 
+    producer = Producer(config)
     collector = PSStreamCollector(producer, topic=topic, authorize_f=authorize_request)
     site = server.Site(collector)
     endpoint = endpoints.TCP4ServerEndpoint(reactor, int(port))

--- a/ps_stream/publisher.py
+++ b/ps_stream/publisher.py
@@ -7,6 +7,7 @@ from xml.etree import ElementTree
 
 import ujson as json
 import yaml
+from confluent_kafka import Consumer, Producer
 from confluent_kafka import KafkaError
 
 from .utils import element_to_obj
@@ -106,7 +107,9 @@ class PSStreamPublisher(object):
         return key_format and key_format.format(**record_data)
 
 
-def publish(consumer, producer, source_topics=None, target_topic=None, target_prefix=None):
+def publish(config, source_topics=None, target_topic=None, target_prefix=None):
+    consumer = Consumer(config)
+    producer = Producer(config)
     publisher = PSStreamPublisher(
         consumer, producer,
         source_topics=source_topics, target_topic=target_topic, target_prefix=target_prefix)

--- a/ps_stream/publisher.py
+++ b/ps_stream/publisher.py
@@ -108,8 +108,15 @@ class PSStreamPublisher(object):
 
 
 def publish(config, source_topics=None, target_topic=None, target_prefix=None):
-    consumer = Consumer(config)
-    producer = Producer(config)
+    consumer_config = {**config, ** {
+        'default.topic.config': {
+            'auto.offset.reset': 'smallest',
+            'auto.commit.interval.ms': 5000
+        }
+    }}
+    producer_config = config
+    consumer = Consumer(consumer_config)
+    producer = Producer(producer_config)
     publisher = PSStreamPublisher(
         consumer, producer,
         source_topics=source_topics, target_topic=target_topic, target_prefix=target_prefix)


### PR DESCRIPTION
If the message consumer for the publish command does not have an
existing committed offset, start reading messages from the
source_topics at the smallest offset for their respective partitions.
This helps ensure that all available collected transactions are
processed.

Resolves #28 