### PR TITLE
Ignore namespaces in elements

### DIFF
--- a/ps_stream/collector.py
+++ b/ps_stream/collector.py
@@ -57,8 +57,8 @@ class PSStreamCollector(resource.Resource):
         request.content.seek(0, 0)
         for event, e in ElementTree.iterparse(request.content, events=('start', 'end')):
             if event == 'start' and psft_message_name is None:
-                psft_message_name = e.tag
-            elif event == 'end' and e.tag == 'FieldTypes':
+                psft_message_name = e.tag.split('}', 1)[-1]
+            elif event == 'end' and e.tag.split('}', 1)[-1] == 'FieldTypes':
                 field_types = element_to_obj(e, value_f=field_type)
                 break
 
@@ -66,7 +66,7 @@ class PSStreamCollector(resource.Resource):
         transaction_index = 1
         request.content.seek(0, 0)
         for event, e in ElementTree.iterparse(request.content, events=('end',)):
-            if e.tag == 'Transaction':
+            if e.tag.split('}', 1)[-1] == 'Transaction':
                 transaction = ElementTree.tostring(e, encoding='unicode')
                 message = {
                     'TransactionID': transaction_id,

--- a/ps_stream/utils.py
+++ b/ps_stream/utils.py
@@ -9,12 +9,12 @@ def element_to_obj(element, map_class=dict, value_f=element_text, wrap_value=Tru
     value = None
 
     if len(element) > 0:
-        child_values = map(lambda e: (e.tag, element_to_obj(
+        child_values = map(lambda e: (e.tag.split('}', 1)[-1], element_to_obj(
             e, map_class=map_class, value_f=value_f, wrap_value=False)), element)
         value = map_class(child_values)
     else:
         value = value_f(element)
 
     if wrap_value:
-        value = {element.tag: value}
+        value = {element.tag.split('}', 1)[-1]: value}
     return value


### PR DESCRIPTION
Unconditionally ignore namespaces when processing XML elements. This
should probably be improved with actual namespace support for these
messages.