### PR TITLE
Update base image tag to 3.6.2-0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ucalgary/python-librdkafka:3.6.0-0.9.4
+FROM ucalgary/python-librdkafka:3.6.2-0.11.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Update the base image from ucalgary/python-librdkafka:3.6.0-0.9.4 to
ucalgary/python-librdkafka:3.6.2-0.11.0. This notable changes the OS
base from Alpine 3.4 to Alpine 3.6.

Closes #38 